### PR TITLE
홈 화면 및 설정 화면에 월 예산 기능 추가

### DIFF
--- a/src/api/monthlyBudget.js
+++ b/src/api/monthlyBudget.js
@@ -1,0 +1,15 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: 'http://localhost:3000',
+});
+
+export const getMonthlyBudget = (month) =>
+  api.get('/monthlyBudget', {
+    params: { month },
+  });
+
+export const createMonthlyBudget = (data) => api.post('/monthlyBudget', data);
+
+export const updateMonthlyBudget = (id, data) =>
+  api.put(`/monthlyBudget/${id}`, data);

--- a/src/stores/monthlyBudgetStore.js
+++ b/src/stores/monthlyBudgetStore.js
@@ -1,0 +1,69 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import {
+  getMonthlyBudget,
+  createMonthlyBudget,
+  updateMonthlyBudget,
+} from '../api/monthlyBudget';
+
+const createDefaultBudget = (month = '') => ({
+  id: '',
+  month,
+  total: 0,
+  categories: {},
+});
+
+const normalizeBudget = (data, month) => ({
+  ...createDefaultBudget(month),
+  ...data,
+  month: data?.month ?? month,
+  categories: data?.categories ?? {},
+});
+
+const normalizeCategoryPayload = (categories = {}) => {
+  return Object.fromEntries(
+    Object.entries(categories)
+      .map(([name, amount]) => [name, Number(amount) || 0])
+      .filter(([, amount]) => amount > 0),
+  );
+};
+
+export const useMonthlyBudgetStore = defineStore('monthlyBudget', () => {
+  const currentBudget = ref(createDefaultBudget());
+
+  const fetchMonthlyBudgetByMonth = async (month) => {
+    try {
+      const res = await getMonthlyBudget(month);
+      const budget = res.data?.[0];
+      currentBudget.value = budget
+        ? normalizeBudget(budget, month)
+        : createDefaultBudget(month);
+    } catch (error) {
+      console.error('Failed to fetch monthly budget:', error);
+      currentBudget.value = createDefaultBudget(month);
+    }
+  };
+
+  const saveMonthlyBudgetByMonth = async (month, payload) => {
+    const data = {
+      id: currentBudget.value?.id || month,
+      month,
+      total: Number(payload?.total) || 0,
+      categories: normalizeCategoryPayload(payload?.categories),
+    };
+
+    if (currentBudget.value?.id) {
+      await updateMonthlyBudget(currentBudget.value.id, data);
+    } else {
+      await createMonthlyBudget(data);
+    }
+
+    currentBudget.value = normalizeBudget(data, month);
+  };
+
+  return {
+    currentBudget,
+    fetchMonthlyBudgetByMonth,
+    saveMonthlyBudgetByMonth,
+  };
+});

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -2,23 +2,96 @@
   <div class="dashboard">
     <div class="summary-cards">
       <div class="card income-card">
-        <div class="card-label">총수입</div>
+        <div class="card-label">수입</div>
         <div class="card-amount income">+{{ formatAmount(totalIncome) }}</div>
       </div>
       <div class="card expense-card">
-        <div class="card-label">총지출</div>
+        <div class="card-label">지출</div>
         <div class="card-amount expense">-{{ formatAmount(totalExpense) }}</div>
       </div>
       <div class="card balance-card">
-        <div class="card-label">최종 금액</div>
+        <div class="card-label">잔액</div>
         <div class="card-amount balance">{{ formatAmount(netBalance) }}</div>
+      </div>
+      <div class="card budget-card">
+        <div class="card-label">남은 예산</div>
+        <div
+          class="card-amount"
+          :class="budgetRemaining >= 0 ? 'balance' : 'expense'"
+        >
+          {{ totalBudget ? formatAmount(budgetRemaining) : '예산 설정하기' }}
+        </div>
+      </div>
+    </div>
+
+    <div class="panel budget-panel">
+      <div class="panel-header">
+        <div class="panel-title-group">
+          <span class="panel-title">월 예산 현황</span>
+          <span class="panel-caption">홈에서는 핵심 정보만 보여줘요</span>
+        </div>
+        <RouterLink to="/settings" class="view-all">예산 설정</RouterLink>
+      </div>
+
+      <div v-if="hasBudget" class="budget-overview">
+        <div class="budget-copy">
+          <div class="budget-heading">
+            <strong>{{ monthStore.label }} 예산</strong>
+            <span class="budget-rate">{{ Math.round(budgetUsageRate) }}%</span>
+          </div>
+          <div class="budget-progress">
+            <div
+              class="budget-progress-value"
+              :style="{ width: `${budgetUsageRate}%` }"
+            />
+          </div>
+          <div class="budget-caption">
+            <span>전체 예산 {{ formatAmount(totalBudget) }}</span>
+            <span>사용 금액 {{ formatAmount(totalExpense) }}</span>
+            <span
+              :class="budgetRemaining >= 0 ? 'budget-positive' : 'budget-over'"
+            >
+              {{
+                budgetRemaining >= 0
+                  ? `${formatAmount(budgetRemaining)} 남음`
+                  : `${formatAmount(Math.abs(budgetRemaining))} 초과`
+              }}
+            </span>
+          </div>
+        </div>
+
+        <div class="budget-summary">
+          <div class="budget-stat">
+            <span class="budget-stat-label">예산</span>
+            <strong>{{ formatAmount(totalBudget) }}</strong>
+          </div>
+          <div class="budget-stat">
+            <span class="budget-stat-label">지출</span>
+            <strong>{{ formatAmount(totalExpense) }}</strong>
+          </div>
+          <div class="budget-stat">
+            <span class="budget-stat-label">남은 예산</span>
+            <strong
+              :class="budgetRemaining >= 0 ? 'budget-positive' : 'budget-over'"
+            >
+              {{ formatAmount(Math.abs(budgetRemaining)) }}
+            </strong>
+          </div>
+        </div>
+      </div>
+
+      <div v-else class="empty">
+        아직 월 예산이 없어요. 설정에서 예산을 추가하면 지출 진행률을 볼 수 있어요.
       </div>
     </div>
 
     <div class="panels">
       <div class="panel">
         <div class="panel-header">
-          <span class="panel-title">최근 거래내역</span>
+          <div class="panel-title-group">
+            <span class="panel-title">최근 거래 내역</span>
+            <span class="panel-caption">최근 5일</span>
+          </div>
           <RouterLink to="/transactions" class="view-all">전체 보기</RouterLink>
         </div>
         <div class="transaction-list">
@@ -55,25 +128,27 @@
             </div>
             <div class="tx-info">
               <div class="tx-category">{{ tx.category }}</div>
-              <div class="tx-memo">{{ tx.memo }}</div>
+              <div class="tx-memo">{{ getTransactionDescription(tx) }}</div>
             </div>
             <div class="tx-right">
               <div class="tx-amount" :class="tx.type">
-                {{ tx.type === 'expense' ? '-' : '+'
-                }}{{ formatAmount(tx.amount) }}
+                {{ tx.type === 'expense' ? '-' : '+' }}{{ formatAmount(tx.amount) }}
               </div>
               <div class="tx-date">{{ formatDate(tx.date) }}</div>
             </div>
           </div>
           <div v-if="recentTransactions.length === 0" class="empty">
-            최근 거래내역이 없습니다.
+            최근 5일 거래 내역이 없어요.
           </div>
         </div>
       </div>
 
       <div class="panel">
         <div class="panel-header">
-          <span class="panel-title">카테고리별 지출</span>
+          <div class="panel-title-group">
+            <span class="panel-title">카테고리별 지출</span>
+            <span class="panel-caption">이번 달 기준</span>
+          </div>
         </div>
         <div class="category-bar" v-if="expenseByCategory.length > 0">
           <div
@@ -100,7 +175,7 @@
             <span class="legend-amount">{{ formatAmount(cat.total) }}</span>
           </div>
           <div v-if="expenseByCategory.length === 0" class="empty">
-            지출 내역이 없습니다.
+            이번 달 지출 데이터가 없어요.
           </div>
         </div>
       </div>
@@ -114,63 +189,118 @@ import { RouterLink } from 'vue-router';
 import { storeToRefs } from 'pinia';
 import { useBudgetStore } from '../stores/budgetStore';
 import { useMonthStore } from '../stores/monthStore';
+import { useMonthlyBudgetStore } from '../stores/monthlyBudgetStore';
 
-const COLORS = [
-  '#ef4444',
-  '#3b82f6',
-  '#f59e0b',
-  '#22c55e',
-  '#a855f7',
-  '#ec4899',
-];
+const COLORS = ['#ef4444', '#3b82f6', '#f59e0b', '#22c55e', '#a855f7', '#ec4899'];
 
 const budgetStore = useBudgetStore();
 const monthStore = useMonthStore();
-const { transactions: budgetList } = storeToRefs(budgetStore);
-const load = () => budgetStore.fetchTransactions();
+const monthlyBudgetStore = useMonthlyBudgetStore();
+
+const { transactions } = storeToRefs(budgetStore);
+const { currentBudget } = storeToRefs(monthlyBudgetStore);
+
+const load = async () => {
+  await Promise.all([
+    budgetStore.fetchTransactions(),
+    monthlyBudgetStore.fetchMonthlyBudgetByMonth(monthStore.yyyyMM),
+  ]);
+};
 
 onMounted(load);
 watch(() => monthStore.yyyyMM, load);
 
+const monthTransactions = computed(() =>
+  transactions.value.filter((transaction) =>
+    String(transaction.date ?? '').startsWith(monthStore.yyyyMM),
+  ),
+);
+
 const totalIncome = computed(() =>
-  budgetList.value
-    .filter((t) => t.type === 'income')
-    .reduce((s, t) => s + t.amount, 0),
+  monthTransactions.value
+    .filter((transaction) => transaction.type === 'income')
+    .reduce((sum, transaction) => sum + Number(transaction.amount || 0), 0),
 );
 
 const totalExpense = computed(() =>
-  budgetList.value
-    .filter((t) => t.type === 'expense')
-    .reduce((s, t) => s + t.amount, 0),
+  monthTransactions.value
+    .filter((transaction) => transaction.type === 'expense')
+    .reduce((sum, transaction) => sum + Number(transaction.amount || 0), 0),
 );
 
 const netBalance = computed(() => totalIncome.value - totalExpense.value);
+const totalBudget = computed(() => Number(currentBudget.value?.total) || 0);
+const budgetRemaining = computed(() => totalBudget.value - totalExpense.value);
+const budgetUsageRate = computed(() => {
+  if (!totalBudget.value) return 0;
+  return Math.min(100, (totalExpense.value / totalBudget.value) * 100);
+});
+
+const padNumber = (value) => String(value).padStart(2, '0');
+const formatDateKey = (date) => {
+  const year = date.getFullYear();
+  const month = padNumber(date.getMonth() + 1);
+  const day = padNumber(date.getDate());
+  return `${year}-${month}-${day}`;
+};
+
+const recentTransactionEndKey = computed(() => {
+  const today = new Date();
+  const currentMonthKey = `${today.getFullYear()}-${padNumber(today.getMonth() + 1)}`;
+
+  if (monthStore.yyyyMM === currentMonthKey) {
+    return formatDateKey(today);
+  }
+
+  const lastDateOfMonth = new Date(monthStore.year, monthStore.month, 0);
+  return formatDateKey(lastDateOfMonth);
+});
+
+const recentTransactionStartKey = computed(() => {
+  const endDate = new Date(`${recentTransactionEndKey.value}T00:00:00`);
+  endDate.setDate(endDate.getDate() - 4);
+  return formatDateKey(endDate);
+});
 
 const recentTransactions = computed(() =>
-  [...budgetList.value]
-    .sort((a, b) => b.date.localeCompare(a.date))
-    .slice(0, 5),
+  [...monthTransactions.value]
+    .filter((transaction) => {
+      const dateKey = String(transaction.date ?? '');
+      return (
+        dateKey >= recentTransactionStartKey.value &&
+        dateKey <= recentTransactionEndKey.value
+      );
+    })
+    .sort((a, b) => String(b.date).localeCompare(String(a.date)))
 );
 
 const expenseByCategory = computed(() => {
-  const map = {};
-  budgetList.value
-    .filter((t) => t.type === 'expense')
-    .forEach((t) => {
-      map[t.category] = (map[t.category] || 0) + t.amount;
+  const expenseMap = {};
+
+  monthTransactions.value
+    .filter((transaction) => transaction.type === 'expense')
+    .forEach((transaction) => {
+      expenseMap[transaction.category] =
+        (expenseMap[transaction.category] || 0) + Number(transaction.amount || 0);
     });
-  const total = Object.values(map).reduce((s, v) => s + v, 0);
-  return Object.entries(map)
+
+  const total = Object.values(expenseMap).reduce((sum, amount) => sum + amount, 0);
+
+  return Object.entries(expenseMap)
     .sort((a, b) => b[1] - a[1])
-    .map(([name, amt]) => ({
+    .map(([name, amount]) => ({
       name,
-      total: amt,
-      ratio: total ? (amt / total) * 100 : 0,
+      total: amount,
+      ratio: total ? (amount / total) * 100 : 0,
     }));
 });
 
-const formatAmount = (n) => Number(n).toLocaleString();
-const formatDate = (d) => d?.slice(5).replace('-', '.') ?? '';
+const hasBudget = computed(() => totalBudget.value > 0);
+
+const formatAmount = (value) => Number(value || 0).toLocaleString();
+const formatDate = (date) => date?.slice(5).replace('-', '.') ?? '';
+const getTransactionDescription = (transaction) =>
+  transaction.memo || transaction.detailCategory || '상세 메모 없음';
 </script>
 
 <style scoped>
@@ -182,15 +312,21 @@ const formatDate = (d) => d?.slice(5).replace('-', '.') ?? '';
 
 .summary-cards {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 16px;
 }
 
 .card {
   background: var(--card-bg);
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: 14px;
   padding: 20px 24px;
+}
+
+.budget-card {
+  background:
+    radial-gradient(circle at top right, rgba(34, 197, 94, 0.14), transparent 30%),
+    var(--card-bg);
 }
 
 .card-label {
@@ -208,38 +344,52 @@ const formatDate = (d) => d?.slice(5).replace('-', '.') ?? '';
 .income {
   color: var(--income);
 }
+
 .expense {
   color: var(--expense);
 }
+
 .balance {
   color: var(--balance);
-}
-
-.panels {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 16px;
-  align-items: start;
 }
 
 .panel {
   background: var(--card-bg);
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: 14px;
   padding: 20px 24px;
+}
+
+.budget-panel {
+  background:
+    radial-gradient(circle at top right, rgba(96, 165, 250, 0.12), transparent 28%),
+    linear-gradient(135deg, rgba(34, 197, 94, 0.1), transparent 60%),
+    var(--card-bg);
 }
 
 .panel-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 12px;
   margin-bottom: 16px;
+}
+
+.panel-title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
 .panel-title {
   font-size: 14px;
   font-weight: 600;
   color: var(--text-bright);
+}
+
+.panel-caption {
+  font-size: 12px;
+  color: var(--text-muted);
 }
 
 .view-all {
@@ -249,6 +399,91 @@ const formatDate = (d) => d?.slice(5).replace('-', '.') ?? '';
 
 .view-all:hover {
   text-decoration: underline;
+}
+
+.budget-overview {
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.28);
+  padding: 18px;
+}
+
+.budget-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.budget-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-bright);
+}
+
+.budget-rate {
+  font-size: 13px;
+  font-weight: 700;
+  color: #93c5fd;
+}
+
+.budget-progress {
+  width: 100%;
+  height: 12px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(148, 163, 184, 0.18);
+}
+
+.budget-progress-value {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #3b82f6, #22c55e);
+}
+
+.budget-caption {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.budget-positive {
+  color: #86efac;
+}
+
+.budget-over {
+  color: #fca5a5;
+}
+
+.budget-summary {
+  margin-top: 18px;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.budget-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.budget-stat-label {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.panels {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  align-items: start;
 }
 
 .transaction-item {
@@ -277,6 +512,7 @@ const formatDate = (d) => d?.slice(5).replace('-', '.') ?? '';
   background: rgba(239, 68, 68, 0.15);
   color: var(--expense);
 }
+
 .tx-icon.income {
   background: rgba(59, 130, 246, 0.15);
   color: var(--income);
@@ -310,6 +546,7 @@ const formatDate = (d) => d?.slice(5).replace('-', '.') ?? '';
   font-size: 13px;
   font-weight: 600;
 }
+
 .tx-date {
   font-size: 11px;
   color: var(--text-muted);
@@ -354,6 +591,7 @@ const formatDate = (d) => d?.slice(5).replace('-', '.') ?? '';
   font-size: 13px;
   color: var(--text);
 }
+
 .legend-amount {
   font-size: 13px;
   font-weight: 600;
@@ -365,5 +603,28 @@ const formatDate = (d) => d?.slice(5).replace('-', '.') ?? '';
   color: var(--text-muted);
   padding: 16px 0;
   text-align: center;
+}
+
+@media (max-width: 1080px) {
+  .summary-cards {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .panels {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .summary-cards,
+  .budget-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .panel-header,
+  .budget-heading {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }
 </style>

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -1,23 +1,92 @@
 <template>
   <div class="settings-view">
-    <!-- Recurring Expenses -->
+    <div class="section-card budget-card">
+      <div class="section-header">
+        <div>
+          <h2 class="section-title">월 예산</h2>
+          <p class="section-subtitle">{{ monthStore.label }} 예산 목표</p>
+        </div>
+        <button class="btn-save-inline" @click="saveBudget">예산 저장</button>
+      </div>
+
+      <div class="budget-summary">
+        <div class="summary-badge">
+          <span class="summary-label">총예산</span>
+          <strong>{{ formatAmount(totalBudgetValue) }}</strong>
+        </div>
+        <div class="summary-badge">
+          <span class="summary-label">카테고리 예산</span>
+          <strong>{{ activeCategoryBudgetCount }}</strong>
+        </div>
+        <div class="summary-badge" :class="{ warning: budgetGap < 0 }">
+          <span class="summary-label">남은 배분</span>
+          <strong>{{ budgetGapLabel }}</strong>
+        </div>
+      </div>
+
+      <div class="budget-form">
+        <div class="field">
+          <label class="field-label">
+            월 총예산 <span class="badge required">필수</span>
+          </label>
+          <input
+            class="form-input"
+            type="text"
+            inputmode="numeric"
+            :value="totalBudgetDisplay"
+            @input="onTotalBudgetInput"
+            placeholder="0"
+          />
+        </div>
+
+        <div class="budget-grid">
+          <div
+            v-for="category in expenseCategories"
+            :key="category.id"
+            class="budget-item"
+          >
+            <label class="field-label">{{ category.name }}</label>
+            <input
+              class="form-input"
+              type="text"
+              inputmode="numeric"
+              :value="categoryBudgetDisplays[category.name] ?? ''"
+              @input="onCategoryBudgetInput(category.name, $event)"
+              placeholder="0"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+
     <div class="section-card">
       <div class="section-header">
-        <h2 class="section-title">Recurring expenses</h2>
+        <div>
+          <h2 class="section-title">고정 지출</h2>
+          <p class="section-subtitle">매달 나가는 고정 지출을 관리해요</p>
+        </div>
         <button class="btn-add" @click="showForm = !showForm">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+          >
             <line x1="12" y1="5" x2="12" y2="19" />
             <line x1="5" y1="12" x2="19" y2="12" />
           </svg>
-          Add
+          추가
         </button>
       </div>
 
-      <!-- Add Form -->
       <div v-if="showForm" class="add-form">
         <div class="form-row">
           <div class="field">
-            <label class="field-label">Category <span class="badge required">required</span></label>
+            <label class="field-label">
+              카테고리 <span class="badge required">필수</span>
+            </label>
             <CategorySelect
               class="form-select"
               v-model="newItem.category"
@@ -25,13 +94,22 @@
             />
           </div>
           <div class="field">
-            <label class="field-label">Detail <span class="badge optional">optional</span></label>
-            <input class="form-input" type="text" v-model="newItem.detailCategory" placeholder="e.g. Netflix" />
+            <label class="field-label">
+              상세 항목 <span class="badge optional">선택</span>
+            </label>
+            <input
+              class="form-input"
+              type="text"
+              v-model="newItem.detailCategory"
+              placeholder="예: 넷플릭스"
+            />
           </div>
         </div>
         <div class="form-row">
           <div class="field">
-            <label class="field-label">Amount <span class="badge required">required</span></label>
+            <label class="field-label">
+              금액 <span class="badge required">필수</span>
+            </label>
             <input
               class="form-input"
               type="text"
@@ -42,38 +120,66 @@
             />
           </div>
           <div class="field">
-            <label class="field-label">Day of month <span class="badge required">required</span></label>
-            <input class="form-input" type="number" v-model="newItem.day" placeholder="1" min="1" max="31" />
+            <label class="field-label">
+              매월 날짜 <span class="badge required">필수</span>
+            </label>
+            <input
+              class="form-input"
+              type="number"
+              v-model="newItem.day"
+              placeholder="1"
+              min="1"
+              max="31"
+            />
           </div>
         </div>
         <div class="form-actions">
-          <button class="btn btn-save" @click="addItem">Save</button>
-          <button class="btn btn-cancel" @click="closeForm">Cancel</button>
+          <button class="btn btn-save" @click="addItem">저장</button>
+          <button class="btn btn-cancel" @click="closeForm">취소</button>
         </div>
       </div>
 
-      <!-- List -->
       <div class="expense-list">
         <div v-if="periodicExpenses.length === 0" class="empty">
-          No recurring expenses
+          등록된 고정 지출이 없어요
         </div>
-        <div v-for="item in periodicExpenses" :key="item.id" class="expense-item">
+        <div
+          v-for="item in periodicExpenses"
+          :key="item.id"
+          class="expense-item"
+        >
           <div class="expense-icon">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+            >
               <circle cx="12" cy="12" r="10" />
               <polyline points="12 6 12 12 16 14" />
             </svg>
           </div>
           <div class="expense-info">
-            <span class="expense-name">{{ item.detailCategory || item.category }}</span>
-            <span class="expense-sub">Monthly / {{ item.category }}</span>
+            <span class="expense-name">{{
+              item.detailCategory || item.category
+            }}</span>
+            <span class="expense-sub">매월 / {{ item.category }}</span>
           </div>
           <div class="expense-right">
             <span class="expense-amount">-{{ item.amount.toLocaleString() }}</span>
-            <span class="expense-day">Every {{ item.day }}{{ daySuffix(item.day) }}</span>
+            <span class="expense-day">매월 {{ item.day }}일</span>
           </div>
-          <button class="btn-delete" @click="removeItem(item.id)" title="Delete">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <button class="btn-delete" @click="removeItem(item.id)" title="삭제">
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+            >
               <line x1="18" y1="6" x2="6" y2="18" />
               <line x1="6" y1="6" x2="18" y2="18" />
             </svg>
@@ -85,25 +191,135 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue';
+import { computed, ref, onMounted, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useProfileStore } from '../stores/profileStore';
 import { useCategoryStore } from '../stores/categoryStore';
+import { useMonthlyBudgetStore } from '../stores/monthlyBudgetStore';
+import { useMonthStore } from '../stores/monthStore';
 import CategorySelect from '../components/CategorySelect.vue';
 
 const profileStore = useProfileStore();
 const categoryStore = useCategoryStore();
+const monthlyBudgetStore = useMonthlyBudgetStore();
+const monthStore = useMonthStore();
+
 const { periodicExpenses } = storeToRefs(profileStore);
 const { expenseCategories } = storeToRefs(categoryStore);
+const { currentBudget } = storeToRefs(monthlyBudgetStore);
 
 const showForm = ref(false);
 const newAmountDisplay = ref('');
-const newItem = ref({ category: '', detailCategory: '', amount: 0, cycle: 'monthly', day: '' });
+const newItem = ref({
+  category: '',
+  detailCategory: '',
+  amount: 0,
+  cycle: 'monthly',
+  day: '',
+});
+
+const totalBudgetValue = ref(0);
+const totalBudgetDisplay = ref('');
+const categoryBudgetValues = ref({});
+const categoryBudgetDisplays = ref({});
+
+const formatAmount = (value) => Number(value || 0).toLocaleString();
+
+const applyFormattedInput = (rawValue, valuesRef, displaysRef, key) => {
+  const raw = rawValue.replace(/[^\d]/g, '');
+  const amount = raw ? Number(raw) : 0;
+  valuesRef.value = {
+    ...valuesRef.value,
+    [key]: amount,
+  };
+  displaysRef.value = {
+    ...displaysRef.value,
+    [key]: raw ? amount.toLocaleString() : '',
+  };
+};
+
+const syncBudgetForm = () => {
+  totalBudgetValue.value = Number(currentBudget.value?.total) || 0;
+  totalBudgetDisplay.value = totalBudgetValue.value
+    ? totalBudgetValue.value.toLocaleString()
+    : '';
+
+  const nextValues = {};
+  const nextDisplays = {};
+
+  expenseCategories.value.forEach((category) => {
+    const amount = Number(currentBudget.value?.categories?.[category.name]) || 0;
+    nextValues[category.name] = amount;
+    nextDisplays[category.name] = amount ? amount.toLocaleString() : '';
+  });
+
+  categoryBudgetValues.value = nextValues;
+  categoryBudgetDisplays.value = nextDisplays;
+};
+
+const loadBudget = async () => {
+  await monthlyBudgetStore.fetchMonthlyBudgetByMonth(monthStore.yyyyMM);
+  syncBudgetForm();
+};
 
 onMounted(async () => {
-  await profileStore.fetchPeriodicExpenses();
-  await categoryStore.fetchCategories();
+  await Promise.all([
+    profileStore.fetchPeriodicExpenses(),
+    categoryStore.fetchCategories(),
+  ]);
+  await loadBudget();
 });
+
+watch(
+  () => monthStore.yyyyMM,
+  async () => {
+    await loadBudget();
+  },
+);
+
+const activeCategoryBudgetCount = computed(() => {
+  return Object.values(categoryBudgetValues.value).filter(
+    (amount) => Number(amount) > 0,
+  ).length;
+});
+
+const categoryBudgetTotal = computed(() => {
+  return Object.values(categoryBudgetValues.value).reduce(
+    (sum, amount) => sum + (Number(amount) || 0),
+    0,
+  );
+});
+
+const budgetGap = computed(() => totalBudgetValue.value - categoryBudgetTotal.value);
+
+const budgetGapLabel = computed(() => {
+  if (!budgetGap.value) return '0';
+  if (budgetGap.value > 0) return `${formatAmount(budgetGap.value)} 남음`;
+  return `${formatAmount(Math.abs(budgetGap.value))} 초과`;
+});
+
+const onTotalBudgetInput = (e) => {
+  const raw = e.target.value.replace(/[^\d]/g, '');
+  totalBudgetValue.value = raw ? Number(raw) : 0;
+  totalBudgetDisplay.value = raw ? Number(raw).toLocaleString() : '';
+};
+
+const onCategoryBudgetInput = (categoryName, e) => {
+  applyFormattedInput(
+    e.target.value,
+    categoryBudgetValues,
+    categoryBudgetDisplays,
+    categoryName,
+  );
+};
+
+const saveBudget = async () => {
+  await monthlyBudgetStore.saveMonthlyBudgetByMonth(monthStore.yyyyMM, {
+    total: totalBudgetValue.value,
+    categories: categoryBudgetValues.value,
+  });
+  syncBudgetForm();
+};
 
 const onNewAmountInput = (e) => {
   const raw = e.target.value.replace(/[^\d]/g, '');
@@ -112,96 +328,169 @@ const onNewAmountInput = (e) => {
 };
 
 const addItem = async () => {
-  if (!newItem.value.category || !newItem.value.amount || !newItem.value.day) return;
+  if (!newItem.value.category || !newItem.value.amount || !newItem.value.day) {
+    return;
+  }
+
   await profileStore.addPeriodic({ ...newItem.value });
   closeForm();
 };
 
 const closeForm = () => {
   showForm.value = false;
-  newItem.value = { category: '', detailCategory: '', amount: 0, cycle: 'monthly', day: '' };
+  newItem.value = {
+    category: '',
+    detailCategory: '',
+    amount: 0,
+    cycle: 'monthly',
+    day: '',
+  };
   newAmountDisplay.value = '';
 };
 
 const removeItem = async (id) => {
   await profileStore.removePeriodic(id);
 };
-
-const daySuffix = (day) => {
-  if (day === 1 || day === 21 || day === 31) return 'st';
-  if (day === 2 || day === 22) return 'nd';
-  if (day === 3 || day === 23) return 'rd';
-  return 'th';
-};
 </script>
 
 <style scoped>
 .settings-view {
-  max-width: 680px;
+  max-width: 920px;
   margin: 0 auto;
   padding: 4px 0 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
 }
 
 .section-card {
   background: var(--card-bg);
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: 16px;
   padding: 24px 28px;
+}
+
+.budget-card {
+  background:
+    radial-gradient(circle at top right, rgba(34, 197, 94, 0.12), transparent 28%),
+    linear-gradient(135deg, rgba(59, 130, 246, 0.12), transparent 65%),
+    var(--card-bg);
 }
 
 .section-header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
+  gap: 16px;
   margin-bottom: 20px;
 }
 
 .section-title {
-  font-size: 15px;
-  font-weight: 600;
+  font-size: 16px;
+  font-weight: 700;
   color: var(--text-bright);
 }
 
-.btn-add {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  background: var(--accent-bg);
-  border: 1px solid rgba(59, 130, 246, 0.3);
-  color: var(--accent);
+.section-subtitle {
+  margin-top: 6px;
   font-size: 13px;
-  font-weight: 500;
-  padding: 6px 12px;
-  border-radius: 6px;
-  transition: background 0.15s;
+  color: var(--text-muted);
 }
 
-.btn-add:hover {
-  background: rgba(59, 130, 246, 0.2);
+.budget-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 18px;
 }
 
-/* Add Form */
+.summary-badge {
+  min-width: 140px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  background: rgba(15, 23, 42, 0.36);
+}
+
+.summary-badge.warning {
+  border-color: rgba(248, 113, 113, 0.32);
+  color: #fecaca;
+}
+
+.summary-label {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.budget-form,
 .add-form {
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: 14px;
   padding: 18px 20px;
-  margin-bottom: 20px;
   display: flex;
   flex-direction: column;
   gap: 14px;
 }
 
-.form-row {
+.budget-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 14px;
+}
+
+.budget-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.btn-add,
+.btn-save-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 36px;
+  padding: 7px 13px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 600;
+  transition:
+    transform 0.15s ease,
+    background 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.btn-add {
+  background: var(--accent-bg);
+  border: 1px solid rgba(59, 130, 246, 0.3);
+  color: var(--accent);
+}
+
+.btn-save-inline {
+  background: rgba(34, 197, 94, 0.16);
+  border: 1px solid rgba(34, 197, 94, 0.3);
+  color: #86efac;
+}
+
+.btn-add:hover,
+.btn-save-inline:hover {
+  transform: translateY(-1px);
 }
 
 .field {
   display: flex;
   flex-direction: column;
   gap: 6px;
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
 }
 
 .field-label {
@@ -233,7 +522,7 @@ const daySuffix = (day) => {
 .form-select {
   background: var(--card-bg);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: 10px;
   color: var(--text-bright);
   font-size: 14px;
   font-family: var(--sans);
@@ -267,11 +556,14 @@ const daySuffix = (day) => {
 
 .btn {
   padding: 8px 20px;
-  border-radius: 7px;
+  border-radius: 8px;
   font-size: 13px;
   font-weight: 500;
   font-family: var(--sans);
-  transition: background 0.15s, border-color 0.15s, color 0.15s;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s;
 }
 
 .btn-save {
@@ -295,7 +587,6 @@ const daySuffix = (day) => {
   border-color: var(--text-muted);
 }
 
-/* Expense List */
 .empty {
   color: var(--text-muted);
   font-size: 13px;
@@ -371,11 +662,25 @@ const daySuffix = (day) => {
   border-radius: 4px;
   display: flex;
   align-items: center;
-  transition: color 0.15s, background 0.15s;
+  transition:
+    color 0.15s,
+    background 0.15s;
 }
 
 .btn-delete:hover {
   color: var(--expense);
   background: rgba(239, 68, 68, 0.1);
+}
+
+@media (max-width: 860px) {
+  .budget-grid,
+  .form-row {
+    grid-template-columns: 1fr;
+  }
+
+  .section-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
 }
 </style>


### PR DESCRIPTION
홈 화면에 월 예산 현황 카드를 추가했습니다.
홈 화면에서 최근 5일 거래 내역과 카테고리별 지출을 확인할 수 있도록 정리했습니다.
설정 화면에 월 총예산과 카테고리별 예산을 입력/저장하는 기능을 추가했습니다.
고정 지출 관리 영역의 문구를 한글로 정리하고 화면 구성을 개선했습니다.
월별 예산 데이터를 위한 store 및 API 로직을 추가했습니다.